### PR TITLE
Remove formula-only fields from homebrew_casks config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -124,16 +124,6 @@ homebrew_casks:
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
-    install: |
-      bin.install "k"
-      bash_completion.install "completions/k" => "k"
-      zsh_completion.install "completions/_k" => "_k"
-      fish_completion.install "completions/k.fish" => "k.fish"
-    test: |
-      system "#{bin}/k", "--help"
-    dependencies:
-      - name: kubectl
-        type: required
 
 # GitHub Release
 release:


### PR DESCRIPTION
install, test, and dependencies with name/type are Homebrew Formula fields and are not valid in the HomebrewCask goreleaser type.